### PR TITLE
Add support for http proxy environment variables

### DIFF
--- a/lib/requests/http.js
+++ b/lib/requests/http.js
@@ -30,7 +30,8 @@ var httpRequest = function (method, uri, data, additionalHeaders, responseParams
     }
 
     var parsedUrl = url.parse(uri);
-    var isHttp = parsedUrl.protocol === 'http:';
+    var protocol = parsedUrl.protocol.replace(':','');
+    var interface = protocol === 'http' ? http : https;
 
     var options = {
         hostname: parsedUrl.hostname,
@@ -40,7 +41,26 @@ var httpRequest = function (method, uri, data, additionalHeaders, responseParams
         headers: headers
     };
 
-    var interface = isHttp ? http : https;
+    if (process.env[`${protocol}_proxy`]) {
+        /*
+         * Proxied requests don't work with Node's https module so use http to
+         * talk to the proxy server regardless of the endpoint protocol. This
+         * is unsuitable for environments where requests are expected to be
+         * using end-to-end TLS.
+         */
+        interface = http;
+        const proxyUrl = url.parse(process.env.http_proxy);
+        options = {
+            hostname: proxyUrl.hostname,
+            port: proxyUrl.port,
+            path: parsedUrl.href,
+            method: method,
+            headers: {
+                host: parsedUrl.host,
+                ...headers,
+            }
+        };
+    }
 
     var request = interface.request(options, function (res) {
         var rawData = '';


### PR DESCRIPTION
This adds support for http_proxy and https_proxy environment variables when used in a nodejs runtime.
