### PR TITLE
Add support for http timeout config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,9 @@ ModelManifest.xml
 **/CRMDeveloperExtensions.config
 /bfg.jar
 
+# Vim
+*.sw[a-p]
+
 /typings
 /gulpfile.js
 /typings.json

--- a/lib/dynamics-web-api.js
+++ b/lib/dynamics-web-api.js
@@ -157,6 +157,11 @@ function DynamicsWebApi(config) {
             _internalConfig.includeAnnotations = config.includeAnnotations;
         }
 
+        if (config.timeout) {
+            ErrorHelper.numberParameterCheck(config.timeout, "DynamicsWebApi.setConfig", "config.timeout");
+            _internalConfig.timeout = config.timeout;
+        }
+
         if (config.maxPageSize) {
             ErrorHelper.numberParameterCheck(config.maxPageSize, "DynamicsWebApi.setConfig", "config.maxPageSize");
             _internalConfig.maxPageSize = config.maxPageSize;

--- a/lib/requests/http.js
+++ b/lib/requests/http.js
@@ -13,8 +13,18 @@ var parseResponse = require('./helpers/parseResponse');
  * @param {Function} errorCallback - A callback called when a request failed.
  * @param {string} [data] - Data to send in the request.
  * @param {Object} [additionalHeaders] - Additional headers. IMPORTANT! This object does not contain default headers needed for every request.
+ * @param {number} [timeout] - socket timeout for the http request.
  */
-var httpRequest = function (method, uri, data, additionalHeaders, responseParams, successCallback, errorCallback) {
+var httpRequest = function (options) {
+    var method = options.method;
+    var uri = options.uri;
+    var data = options.data;
+    var additionalHeaders = options.additionalHeaders;
+    var responseParams = options.responseParams;
+    var successCallback = options.successCallback;
+    var errorCallback = options.errorCallback;
+    var timeout = options.timeout;
+
     var headers = {};
 
     if (data) {
@@ -38,6 +48,7 @@ var httpRequest = function (method, uri, data, additionalHeaders, responseParams
         port: parsedUrl.port,
         path: parsedUrl.path,
         method: method,
+        timeout: timeout,
         headers: headers
     };
 
@@ -55,6 +66,7 @@ var httpRequest = function (method, uri, data, additionalHeaders, responseParams
             port: proxyUrl.port,
             path: parsedUrl.href,
             method: method,
+            timeout: timeout,
             headers: {
                 host: parsedUrl.host,
                 ...headers,
@@ -111,7 +123,14 @@ var httpRequest = function (method, uri, data, additionalHeaders, responseParams
         });
     });
 
+    request.on('timeout', function (error) {
+      request.abort();
+    });
+
     request.on('error', function (error) {
+        if (request.aborted) {
+          error = new Error('Request timed out: ' + error);
+        }
         responseParams.length = 0;
         errorCallback(error);
     });

--- a/lib/requests/sendRequest.js
+++ b/lib/requests/sendRequest.js
@@ -203,7 +203,17 @@ function sendRequest(method, path, config, data, additionalHeaders, responsePara
                     token);
         }
 
-        executeRequest(method, config.webApiUrl + path, stringifiedData, additionalHeaders, responseParseParams, successCallback, errorCallback, isAsync);
+        executeRequest({
+            method: method,
+            uri: config.webApiUrl + path,
+            data: stringifiedData,
+            additionalHeaders: additionalHeaders,
+            responseParams: responseParseParams,
+            successCallback: successCallback,
+            errorCallback: errorCallback,
+            isAsync: isAsync,
+            timeout: config.timeout,
+        });
     };
 
     //call a token refresh callback only if it is set and there is no "Authorization" header set yet

--- a/lib/requests/xhr.js
+++ b/lib/requests/xhr.js
@@ -11,11 +11,20 @@ var parseResponseHeaders = require('./helpers/parseResponseHeaders');
  * @param {any} responseParams - parameters for parsing the response
  * @param {Function} successCallback - A callback called on success of the request.
  * @param {Function} errorCallback - A callback called when a request failed.
- * @param {boolean} [async] - Indicates if the request needs to be synchronous
+ * @param {boolean} [isAsync] - Indicates if the request needs to be synchronous
  */
-var xhrRequest = function (method, uri, data, additionalHeaders, responseParams, successCallback, errorCallback, async) {
+var xhrRequest = function (options) {
+    var method = options.method;
+    var uri = options.uri;
+    var data = options.data;
+    var additionalHeaders = options.additionalHeaders;
+    var responseParams = options.responseParams;
+    var successCallback = options.successCallback;
+    var errorCallback = options.errorCallback;
+    var isAsync = options.isAsync;
+
     var request = new XMLHttpRequest();
-    request.open(method, uri, async);
+    request.open(method, uri, isAsync);
 
     //set additional headers
     for (var key in additionalHeaders) {


### PR DESCRIPTION
I recently ran into an issue where CRM integrations were not succeeding but not logging failures either. It looks like it was because CRM requests were taking much longer than usual so the client was just waiting. In general client applications should always have a finite timeout set so that badly behaving services like this do not cause hard-to-diagnose cascading failure due to resource exhaustion (in my case this scenario is likely to cause pubsub consumers to be exchausted).

Let me know what you think of this change. I still need to update the XHR client to be compatible with the new method signature. I think in general if a JS method has more than two args then an options parameter should be used. The syntax I've used here is the old verbose style because I'm not sure what the target runtime is. It could be improved by using argument destructuring if that's an option.