### PR TITLE
Make rejected promise always yield error instance

### DIFF
--- a/lib/requests/http.js
+++ b/lib/requests/http.js
@@ -88,21 +88,25 @@ var httpRequest = function (options) {
                     break;
                 }
                 default: // All other statuses are error cases.
-                    var error;
+                    var crmError;
                     try {
                         var errorParsed = JSON.parse(rawData);
 
-                        error = errorParsed.hasOwnProperty('error') && errorParsed.error
+                        crmError = errorParsed.hasOwnProperty('error') && errorParsed.error
                             ? errorParsed.error
                             : { message: errorParsed.Message };
                     } catch (e) {
                         if (rawData.length > 0) {
-                            error = { message: rawData };
+                            crmError = { message: rawData };
                         }
                         else {
-                            error = { message: "Unexpected Error" };
+                            crmError = { message: "Unexpected Error" };
                         }
                     }
+                    var error = new Error();
+                    Object.keys(crmError).forEach(k => {
+                      error[k] = crmError[k];
+                    })
                     error.status = res.statusCode;
                     error.statusText = request.statusText;
                     errorCallback(error);


### PR DESCRIPTION
This change makes all request errors compatible with VError which expects any cause to be an instance of Error.

For example:

```javascript
try {
  return await dynamics.retrieveRequest({ collection, key });
} catch(e) {
  if (e.status == '404') {
    throw new VError({ cause: e, name: 'InvalidMessage' }, 'Equipment not found %j', { key });
  }
  throw new VError(e, 'Failed to get equipment %j', { key });
}
```

Without this change the VError constructor throws "cause is not an Error", masking the error. I think this issue should be fixed in VError too (https://github.com/joyent/node-verror/issues/66).