### PR TITLE
To authorize executeBatch by token parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,6 @@ ModelManifest.xml
 /scripts
 /coverage
 /tests/browser
+
+# Webstorm
+.idea

--- a/lib/dynamics-web-api-callbacks.js
+++ b/lib/dynamics-web-api-callbacks.js
@@ -1577,7 +1577,7 @@ function DynamicsWebApi(config) {
             successCallback(response.data);
         };
 
-        _makeRequest('POST', { ...request, collection: '$batch' }, 'executeBatch', onSuccess, errorCallback);
+        _makeRequest('POST', Object.assign(request, { collection: '$batch' }), 'executeBatch', onSuccess, errorCallback);
     };
 
     /**

--- a/lib/dynamics-web-api-callbacks.js
+++ b/lib/dynamics-web-api-callbacks.js
@@ -1565,7 +1565,10 @@ function DynamicsWebApi(config) {
      * @param {Function} successCallback - The function that will be passed through and be called by a successful response.
      * @param {Function} errorCallback - The function that will be passed through and be called by a failed response.
      */
-    this.executeBatch = function (successCallback, errorCallback, request={}) {
+    this.executeBatch = function (successCallback, errorCallback, request) {
+
+        request = request || {};
+
         ErrorHelper.batchNotStarted(_isBatch);
         ErrorHelper.callbackParameterCheck(successCallback, "DynamicsWebApi.executeBatch", "successCallback");
         ErrorHelper.callbackParameterCheck(errorCallback, "DynamicsWebApi.executeBatch", "errorCallback");

--- a/lib/dynamics-web-api-callbacks.js
+++ b/lib/dynamics-web-api-callbacks.js
@@ -1561,13 +1561,15 @@ function DynamicsWebApi(config) {
 
     /**
      * Executes a batch request. Please call DynamicsWebApi.startBatch() first to start a batch request.
+     * @param request
      * @param {Function} successCallback - The function that will be passed through and be called by a successful response.
      * @param {Function} errorCallback - The function that will be passed through and be called by a failed response.
      */
-    this.executeBatch = function (successCallback, errorCallback) {
+    this.executeBatch = function (successCallback, errorCallback, request={}) {
         ErrorHelper.batchNotStarted(_isBatch);
         ErrorHelper.callbackParameterCheck(successCallback, "DynamicsWebApi.executeBatch", "successCallback");
         ErrorHelper.callbackParameterCheck(errorCallback, "DynamicsWebApi.executeBatch", "errorCallback");
+        ErrorHelper.parameterCheck(request, "DynamicsWebApi.executeBatch", "request");
 
         _isBatch = false;
 
@@ -1575,7 +1577,7 @@ function DynamicsWebApi(config) {
             successCallback(response.data);
         };
 
-        _makeRequest('POST', { collection: '$batch' }, 'executeBatch', onSuccess, errorCallback);
+        _makeRequest('POST', { ...request, collection: '$batch' }, 'executeBatch', onSuccess, errorCallback);
     };
 
     /**

--- a/lib/dynamics-web-api-callbacks.js
+++ b/lib/dynamics-web-api-callbacks.js
@@ -1580,7 +1580,9 @@ function DynamicsWebApi(config) {
             successCallback(response.data);
         };
 
-        _makeRequest('POST', Object.assign(request, { collection: '$batch' }), 'executeBatch', onSuccess, errorCallback);
+        request.collection = '$batch';
+
+        _makeRequest('POST', request, 'executeBatch', onSuccess, errorCallback);
     };
 
     /**

--- a/lib/dynamics-web-api.js
+++ b/lib/dynamics-web-api.js
@@ -1398,7 +1398,7 @@ function DynamicsWebApi(config) {
 		ErrorHelper.batchNotStarted(_isBatch);
 
 		_isBatch = false;
-		return _makeRequest('POST', { ...request, collection: '$batch' }, 'executeBatch')
+		return _makeRequest('POST', Object.assign(request, { collection: '$batch' }), 'executeBatch')
 			.then(function (response) {
 				return response.data;
 			});

--- a/lib/dynamics-web-api.js
+++ b/lib/dynamics-web-api.js
@@ -1400,8 +1400,10 @@ function DynamicsWebApi(config) {
 		ErrorHelper.parameterCheck(request, 'DynamicsWebApi.executeBatch', 'request');
 		ErrorHelper.batchNotStarted(_isBatch);
 
+		request.collection = '$batch';
+
 		_isBatch = false;
-		return _makeRequest('POST', Object.assign(request, { collection: '$batch' }), 'executeBatch')
+		return _makeRequest('POST', request, 'executeBatch')
 			.then(function (response) {
 				return response.data;
 			});

--- a/lib/dynamics-web-api.js
+++ b/lib/dynamics-web-api.js
@@ -1390,13 +1390,15 @@ function DynamicsWebApi(config) {
 
     /**
      * Executes a batch request. Please call DynamicsWebApi.startBatch() first to start a batch request.
+	 * @param request
      * @returns {Promise} D365 Web Api result
      */
-	this.executeBatch = function () {
+	this.executeBatch = function (request={}) {
+		ErrorHelper.parameterCheck(request, 'DynamicsWebApi.executeBatch', 'request');
 		ErrorHelper.batchNotStarted(_isBatch);
 
 		_isBatch = false;
-		return _makeRequest('POST', { collection: '$batch' }, 'executeBatch')
+		return _makeRequest('POST', { ...request, collection: '$batch' }, 'executeBatch')
 			.then(function (response) {
 				return response.data;
 			});

--- a/lib/dynamics-web-api.js
+++ b/lib/dynamics-web-api.js
@@ -1393,7 +1393,10 @@ function DynamicsWebApi(config) {
 	 * @param request
      * @returns {Promise} D365 Web Api result
      */
-	this.executeBatch = function (request={}) {
+	this.executeBatch = function (request) {
+
+		request = request || {};
+
 		ErrorHelper.parameterCheck(request, 'DynamicsWebApi.executeBatch', 'request');
 		ErrorHelper.batchNotStarted(_isBatch);
 

--- a/lib/requests/sendRequest.js
+++ b/lib/requests/sendRequest.js
@@ -216,7 +216,6 @@ function sendRequest(method, path, config, data, additionalHeaders, responsePara
 	var stringifiedData = stringifyData(data, config);
 
 	if (path === '$batch') {
-
 		var batchResult = _convertToBatch(_batchRequestCollection, config);
 
 		stringifiedData = batchResult.body;

--- a/lib/requests/sendRequest.js
+++ b/lib/requests/sendRequest.js
@@ -217,13 +217,6 @@ function sendRequest(method, path, config, data, additionalHeaders, responsePara
 
 	if (path === '$batch') {
 
-		//get token parameter by first batch request
-		if (_batchRequestCollection.length > 0) {
-			if (_batchRequestCollection[0].request.token) {
-				additionalHeaders['Authorization'] = _batchRequestCollection[0].request.token;
-			}
-		}
-
 		var batchResult = _convertToBatch(_batchRequestCollection, config);
 
 		stringifiedData = batchResult.body;

--- a/lib/requests/sendRequest.js
+++ b/lib/requests/sendRequest.js
@@ -216,6 +216,14 @@ function sendRequest(method, path, config, data, additionalHeaders, responsePara
 	var stringifiedData = stringifyData(data, config);
 
 	if (path === '$batch') {
+
+		//get token parameter by first batch request
+		if (_batchRequestCollection.length > 0) {
+			if (_batchRequestCollection[0].request.token) {
+				additionalHeaders['Authorization'] = _batchRequestCollection[0].request.token;
+			}
+		}
+
 		var batchResult = _convertToBatch(_batchRequestCollection, config);
 
 		stringifiedData = batchResult.body;

--- a/tests/callbacks-tests.js
+++ b/tests/callbacks-tests.js
@@ -4491,6 +4491,63 @@ describe("callbacks -", function () {
             });
         });
 
+        describe("update / delete passing a request parameter", function () {
+            var scope;
+            var rBody = mocks.data.batchUpdateDelete;
+            var rBodys = rBody.split('\n');
+            var checkBody = '';
+            for (var i = 0; i < rBodys.length; i++) {
+                checkBody += rBodys[i];
+            }
+            before(function () {
+                var response = mocks.responses.batchUpdateDelete;
+                scope = nock(mocks.webApiUrl + '$batch', {
+                    reqheaders: {
+                        Authorization: "Bearer 123"
+                    }
+                })
+                    .filteringRequestBody(function (body) {
+                        body = body.replace(/dwa_batch_[\d\w]{8}-[\d\w]{4}-[\d\w]{4}-[\d\w]{4}-[\d\w]{12}/g, 'dwa_batch_XXX');
+                        body = body.replace(/changeset_[\d\w]{8}-[\d\w]{4}-[\d\w]{4}-[\d\w]{4}-[\d\w]{12}/g, 'changeset_XXX');
+                        var bodys = body.split('\n');
+
+                        var resultBody = '';
+                        for (var i = 0; i < bodys.length; i++) {
+                            resultBody += bodys[i];
+                        }
+                        return resultBody;
+                    })
+                    .post("", checkBody)
+                    .reply(response.status, response.responseText, response.responseHeaders);
+            });
+
+            after(function () {
+                nock.cleanAll();
+            });
+
+            it("returns a correct response", function (done) {
+                dynamicsWebApiTest.startBatch();
+
+                dynamicsWebApiTest.update(mocks.data.testEntityId2, 'records', { firstname: "Test", lastname: "Batch!" });
+                dynamicsWebApiTest.deleteRecord(mocks.data.testEntityId2, 'records', null, null, 'firstname');
+
+                dynamicsWebApiTest.executeBatch(function (object) {
+                    expect(object.length).to.be.eq(2);
+
+                    expect(object[0]).to.be.true;
+                    expect(object[1]).to.be.undefined;
+
+                    done();
+                }, function (object) {
+                    done(object);
+                }, { token: '123' });
+            });
+
+            it("all requests have been made", function () {
+                expect(scope.isDone()).to.be.true;
+            });
+        });
+
         describe("update / delete - returns an error", function () {
             var scope;
             var rBody = mocks.data.batchUpdateDelete;

--- a/types/dynamics-web-api-callbacks.d.ts
+++ b/types/dynamics-web-api-callbacks.d.ts
@@ -529,8 +529,9 @@ declare class DynamicsWebApi {
      * Executes a batch request. Please call DynamicsWebApi.startBatch() first to start a batch request.
      * @param successCallback - The function that will be passed through and be called by a successful response.
      * @param errorCallback - The function that will be passed through and be called by a failed response.
+     * @param request
      */
-	executeBatch(successCallback: Function, errorCallback: Function): void;
+	executeBatch(successCallback: Function, errorCallback: Function, request?: Request): void;
     /**
      * Creates a new instance of DynamicsWebApi
      *

--- a/types/dynamics-web-api.d.ts
+++ b/types/dynamics-web-api.d.ts
@@ -434,7 +434,7 @@ declare class DynamicsWebApi {
     /**
      * Executes a batch request. Please call DynamicsWebApi.startBatch() first to start a batch request.
      */
-	executeBatch(): Promise<any[]>;
+	executeBatch(request?: Request): Promise<any[]>;
     /**
      * Creates a new instance of DynamicsWebApi
      *


### PR DESCRIPTION
I fixed the batch execution in case of added batch requests have a token parameter.
It takes token parameter by first request added.
Without this change the batch execution returns 401 error.