### PR TITLE
add use strict and fix undeclared variables

### DIFF
--- a/lib/utilities/RequestConverter.js
+++ b/lib/utilities/RequestConverter.js
@@ -1,4 +1,5 @@
-﻿var DWA = require('../dwa');
+﻿'use strict';
+var DWA = require('../dwa');
 var ErrorHelper = require('../helpers/ErrorHelper');
 var buildPreferHeader = require('./buildPreferHeader');
 
@@ -78,11 +79,8 @@ function convertRequestOptions(request, functionName, url, joinSymbol, config) {
             var filterResult = request.filter;
 
             //fix bug 2018-06-11
+            var m;
             while ((m = removeBracketsFromGuidReg.exec(filterResult)) !== null) {
-                if (m.index === removeBracketsFromGuidReg.lastIndex) {
-                    regex.lastIndex++;
-                }
-
                 var replacement = m[0].endsWith(')') ? ')' : ' ';
                 filterResult = filterResult.replace(m[0], ' ' + m[1] + replacement);
             }
@@ -142,7 +140,7 @@ function convertRequestOptions(request, functionName, url, joinSymbol, config) {
             ErrorHelper.stringParameterCheck(request.impersonate, 'DynamicsWebApi.' + functionName, "request.impersonate");
             headers['MSCRMCallerID'] = ErrorHelper.guidParameterCheck(request.impersonate, 'DynamicsWebApi.' + functionName, "request.impersonate");
         }
-        
+
         if (request.impersonateAAD) {
             ErrorHelper.stringParameterCheck(request.impersonateAAD, 'DynamicsWebApi.' + functionName, "request.impersonateAAD");
             headers['CallerObjectId'] = ErrorHelper.guidParameterCheck(request.impersonateAAD, 'DynamicsWebApi.' + functionName, "request.impersonateAAD");

--- a/tests/callbacks-tests.js
+++ b/tests/callbacks-tests.js
@@ -1,4 +1,5 @@
-﻿var chai = require('chai');
+﻿'use strict';
+var chai = require('chai');
 var expect = chai.expect;
 var nock = require('nock');
 var sinon = require('sinon');
@@ -5272,7 +5273,7 @@ describe("callbacks -", function () {
             });
 
             it("sends the request to the right end point", function (done) {
-                dynamicsWebApiCopy = dynamicsWebApi81.initializeInstance({ webApiVersion: "8.2" });
+                var dynamicsWebApiCopy = dynamicsWebApi81.initializeInstance({ webApiVersion: "8.2" });
                 dynamicsWebApiCopy.retrieveMultipleRequest({ collection: "tests" }, function (object) {
                     expect(object).to.deep.equal(mocks.responses.multiple());
                     done();

--- a/tests/common-tests.js
+++ b/tests/common-tests.js
@@ -1,4 +1,5 @@
-﻿var chai = require('chai');
+﻿'use strict';
+var chai = require('chai');
 var expect = chai.expect;
 
 var nock = require('nock');
@@ -836,7 +837,7 @@ describe("RequestConverter.convertRequestOptions -", function () {
 			returnRepresentation: null
 		};
 
-		result = RequestConverter.convertRequestOptions(dwaRequest, "", stubUrl);
+		var result = RequestConverter.convertRequestOptions(dwaRequest, "", stubUrl);
 		expect(result).to.deep.equal({ url: stubUrl, query: "", headers: {} });
 	});
 
@@ -863,7 +864,7 @@ describe("RequestConverter.convertRequestOptions -", function () {
 			duplicateDetection: null
 		};
 
-		result = RequestConverter.convertRequestOptions(dwaRequest, "", stubUrl);
+		var result = RequestConverter.convertRequestOptions(dwaRequest, "", stubUrl);
 		expect(result).to.deep.equal({ url: stubUrl, query: "", headers: {} });
 	});
 

--- a/tests/main-tests.js
+++ b/tests/main-tests.js
@@ -1,4 +1,5 @@
-﻿var chai = require('chai');
+﻿'use strict';
+var chai = require('chai');
 var expect = chai.expect;
 var nock = require('nock');
 var sinon = require('sinon');
@@ -5005,7 +5006,7 @@ describe("promises -", function () {
 						expect(object.length).to.be.eq(1);
 
 						expect(object[0].headers).to.deep.equal({
-							"odata-version": "4.0", "req_id": "5fe339e5-c75e-4dad-9597-b257ebce666b", "content-type": "application/json; odata.metadata=minimal" 
+							"odata-version": "4.0", "req_id": "5fe339e5-c75e-4dad-9597-b257ebce666b", "content-type": "application/json; odata.metadata=minimal"
 						});
 
 						expect(object[0].error).to.deep.equal({
@@ -5971,7 +5972,7 @@ describe("promises -", function () {
             });
 
             it("sends the request to the right end point", function (done) {
-                dynamicsWebApiCopy = dynamicsWebApi81.initializeInstance({ webApiVersion: "8.2" });
+                var dynamicsWebApiCopy = dynamicsWebApi81.initializeInstance({ webApiVersion: "8.2" });
                 dynamicsWebApiCopy.retrieveMultipleRequest({ collection: "tests" })
                     .then(function (object) {
                         expect(object).to.deep.equal(mocks.responses.multiple());

--- a/tests/xhr-tests.js
+++ b/tests/xhr-tests.js
@@ -1,4 +1,5 @@
-﻿var chai = require('chai');
+﻿'use strict';
+var chai = require('chai');
 var expect = chai.expect;
 
 var sinon = require('sinon');


### PR DESCRIPTION
I first had an issue with an `undeclared variable 'm'` using a request with a filter, then I noticed it was implicitly declared.
This works for some environments, but not in the browser. Mocha tests still pass because they don't run in strict mode, so the issue was silent.

I then added the `use strict` directive on test files and the `RequestConverter`, making the tests fail and report undeclared variables issues. 

tldr: this fixes undeclared variable issues and adds strict mode in some files.