### PR TITLE
Nullify batchRequestId immediatelly

### DIFF
--- a/lib/dynamics-web-api.js
+++ b/lib/dynamics-web-api.js
@@ -1474,11 +1474,12 @@ function DynamicsWebApi(config) {
 		request.collection = '$batch';
 
 		_isBatch = false;
-		_batchRequestId = null;
-		return _makeRequest('POST', request, 'executeBatch')
+		const promise = _makeRequest('POST', request, 'executeBatch')
 			.then(function (response) {
 				return response.data;
 			});
+		_batchRequestId = null;
+		return promise;
 	};
 
     /**

--- a/lib/dynamics-web-api.js
+++ b/lib/dynamics-web-api.js
@@ -1474,11 +1474,10 @@ function DynamicsWebApi(config) {
 		request.collection = '$batch';
 
 		_isBatch = false;
+		_batchRequestId = null;
 		return _makeRequest('POST', request, 'executeBatch')
 			.then(function (response) {
 				return response.data;
-			}).finally(function () {
-				_batchRequestId = null;
 			});
 	};
 


### PR DESCRIPTION
Sometimes the library threw unhandledException
that parseParams is undefined in parseResponse.js:312

It happens because a single requestId is assigned to two different
requests, and after the first one is done, the info for the second request
is deleted.

A single requestId is assigned because of the batch implementation.
After executeBatch function, the global _batchRequestId is not nulled,
so any further request will get the same requestId, until executeBatch
promise is not finished.

I didn't find to write a test for this in a meaningful manner of time. Nor I found an existing test that is sensitive to this moment.