### PR TITLE
fix args retrieveRelationships method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,7 +1660,8 @@ dynamicsWebApi.retrieveRelationship(metadataId, relationshipType).then(function 
 ### Retrieve Multiple Relationships
 
 ```js
-dynamicsWebApi.retrieveRelationships(['SchemaName', 'MetadataId'], "ReferencedEntity eq 'account'")
+var relationshipType = 'Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata';
+dynamicsWebApi.retrieveRelationships(relationshipType, ['SchemaName', 'MetadataId'], "ReferencedEntity eq 'account'")
 .then(function (relationship) {
     //work with a retrieved relationship
 }).catch(function (error) {


### PR DESCRIPTION
dynamics-web-api v1.7.4

```js
 /**
  * Sends an asynchronous request to retrieve relationship definitions.
  *
  * @param {string} [relationshipType] - Use this parameter to cast a Relationship to a specific type: 1:M or M:M.
  * @param {Array} [select] - Use the $select system query option to limit the properties returned.
  * @param {string} [filter] - Use the $filter system query option to set criteria for which relationships will be returned.
  * @returns {Promise} D365 Web Api result
  */
 this.retrieveRelationships = function(relationshipType, select, filter) {
     var request = {
         collection: "RelationshipDefinitions",
         navigationProperty: relationshipType,
         select: select,
         filter: filter,
     };

     return this.retrieveMultipleRequest(request);
 };
```